### PR TITLE
accept observable fn dict in the jax energy function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ numpy = "*"
 ase = "*"
 h5py = "*"
 mlff = { git = "https://github.com/thorben-frank/mlff.git", branch = "v1.0-lrs-gems", optional = false }
+#mlff = { git = "https://github.com/fbruenig/mlff.git", branch = "dev_fnb", optional = false }
 jraph = { git = "https://github.com/kabylda/jraph.git", branch = "master", optional = false }
 jax-md = { git = "https://github.com/kabylda/jax-md.git", branch = "main" , optional = false }
 glp = { git = "https://github.com/kabylda/glp.git", branch = "electrostatics_neighbourlist", optional = false }

--- a/so3lr/jaxmd_utils.py
+++ b/so3lr/jaxmd_utils.py
@@ -103,7 +103,7 @@ def to_jax_md(
             neighbor_lr,
             obs_fn_kwargs: Dict[str, Dict[str, int]] = {},
             **energy_fn_kwargs
-    ):  
+    ):
         graph = featurizer(R, neighbor, neighbor_lr, **energy_fn_kwargs)
         if obs_fn_kwargs:
             return potential(graph,has_aux=[[True]],**obs_fn_kwargs)

--- a/so3lr/jaxmd_utils.py
+++ b/so3lr/jaxmd_utils.py
@@ -7,6 +7,7 @@ from jax_md.space import DisplacementOrMetricFn, Box
 
 from so3lr.graph import Graph
 
+from typing import Dict
 
 def neighbor_list_featurizer(displacement_fn, species):
     def featurize(R, neighbor, neighbor_lr, **kwargs):
@@ -100,9 +101,13 @@ def to_jax_md(
             R,
             neighbor,
             neighbor_lr,
+            obs_fn_kwargs: Dict[str, Dict[str, int]] = {},
             **energy_fn_kwargs
-    ):
+    ):  
         graph = featurizer(R, neighbor, neighbor_lr, **energy_fn_kwargs)
-        return potential(graph).sum()
+        if obs_fn_kwargs:
+            return potential(graph,has_aux=[[True]],**obs_fn_kwargs)
+        else:
+            return potential(graph).sum()
 
     return neighbor_fn, neighbor_fn_lr, energy_fn


### PR DESCRIPTION
this accepts an observable_fn dict as a new optional argument. The dict is passed through to the stacknet module where the dict keys are used to execute observable modules and submodules and the observables are returned in addition to the energy.