### PR TITLE
removed use_so3lr keyword from help and settings description

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ md-so3lr --help
 
 By only providing an `initial_geometry`, a short NVT simulation is launched.
 Currently, NVT and NPT are supported using the Nosé–Hoover chain thermostat or barostat. For optimization the FIRE algorithm is used as implemented in JAX MD.
-The trajectories will be saved efficiently using `.hdf5` files. In addition, checkpoints can be saved as `.npz` files throughout the simulation to restart it if needed. 
+The trajectories will be saved efficiently using `.hdf5` files. In addition, checkpoints can be saved as `.npz` files throughout the simulation to restart it if needed.
+SO3LR is used by default. In case you want to use your own model you have to specify the path in the settings at `model_path`.
 
 ## Potential energy function
 To obtain a potential energy function which is not specifally tailored for `jax-md` we provide a convenience 

--- a/so3lr/cli/md_settings.md
+++ b/so3lr/cli/md_settings.md
@@ -7,8 +7,6 @@
   Path to the initial geometry file.
 - **`model_path`** (`str`):  
   Path to the model directory.
-- **`use_so3lr`** (`bool`, default: `True`):  
-  Whether to use SO3LR.
 - **`precision`** (`str`, default: `'float32'`):  
   Numerical precision.
 

--- a/so3lr/cli/md_settings.md
+++ b/so3lr/cli/md_settings.md
@@ -27,8 +27,10 @@
   File name for trajectory output.
 - **`restart_save_path`** (`str`, default: `None`):  
   Path to save restart file.
-- **`restart_load_path`** (`str`, default: `None`):  
+- **`restart_load_path`** (`str`, default: `None`):
   Path to load restart file.
+- **`save_exist_ok`** (`bool`, default: `False`):
+  Whether to overwrite existing files.
 
 ### Molecular Dynamics (MD)
 - **`md_dt`** (`float`, default: 0.0005):  

--- a/so3lr/cli/md_so3lr.py
+++ b/so3lr/cli/md_so3lr.py
@@ -40,6 +40,7 @@ hdf5_buffer_size: 5                              # (int) Number of frames to buf
 trajectory_hdf5_file: "trajectory.hdf5"          # (str) Output file for trajectory data in HDF5 format\n
 restart_save_path: null                          # (str) Optional path to save restart data from a previous run\n
 restart_load_path: null                          # (str) Optional path to load restart data from a previous run\n
+save_exist_ok: False                             # (bool) Whether to overwrite existing files when saving trajectory\n
 
 # === Minimization settings ===\n
 min_cycles: 10                                   # (int) Number of minimization cycles to perform\n
@@ -184,7 +185,7 @@ def init_hdf5_store(
         HDF5Store: _description_
     """
     parent_dir = pathlib.Path(save_to).expanduser().resolve().parent
-    parent_dir.mkdir(exist_ok=True)
+    parent_dir.mkdir(exist_ok=exist_ok)
     
     _save_to = pathlib.Path(save_to)
     if _save_to.exists():
@@ -1056,6 +1057,7 @@ def perform_md(
     trajectory_hdf5_file = all_settings.get('trajectory_hdf5_file', 'trajectory.hdf5')
     
     # Handling of restart
+    save_exist_ok = all_settings.get('save_exist_ok', False)
     restart_save_path = all_settings.get('restart_save_path')
     if restart_save_path is not None:
         create_restart = True
@@ -1142,7 +1144,7 @@ def perform_md(
         batch_size=hdf5_buffer_size,
         num_atoms=position.shape[0],
         num_box_entries=1,
-        exist_ok=True
+        exist_ok=save_exist_ok
     )
 
     # Loading the model

--- a/so3lr/cli/md_so3lr.py
+++ b/so3lr/cli/md_so3lr.py
@@ -27,7 +27,6 @@ HELP_STRING = """
 # === General settings ===\n
 initial_geometry: "path/to/geometry.xyz"         # (str) Path to the initial geometry file\n
 model_path: "path/to/model/"                     # (str) Path to the model directory\n
-use_so3lr: True                                  # (bool) Whether to use SO3LR \n
 precision: "float32"                             # (str) Numerical precision, e.g., 'float32' or 'float64'\n
 
 # === Cutoffs and Buffers ===\n


### PR DESCRIPTION
Hey,
I noticed that the help string and the info `.md` file still had the `use_so3lr` keyword in it. But we decided to always use the pre-trained model and only if a model is given in `model_path`, the given model is used instead.

EDIT: Existing files were always overwritten, changed it to be set by user. Default is now that it throws an error when files already exist.