### PR TITLE
NVE CLI fix

### DIFF
--- a/so3lr/cli/so3lr_md.py
+++ b/so3lr/cli/so3lr_md.py
@@ -1614,8 +1614,13 @@ def perform_md(
     md_T = unit_dict['T']
     md_P = unit_dict['P']
 
-    # Setting up the thermostat and/or barostat
-    nhc_tau = md_dt * nhc_thermo
+    # set nhc_tau to 0 for NVE ensemble only
+    if ensemble == 'nve':
+        nhc_tau = 0
+    else:
+        nhc_tau = md_dt * nhc_thermo
+    
+
     nhc_kwargs = {
         'chain_length': nhc_chain_length,
         'chain_steps': nhc_steps,


### PR DESCRIPTION
The NVE ensemble crashed before starting, because the variable nhc_thermo was dropped, but still used for nhc_tau calculation. 
I added a simple if statement setting nhc_tau=0 for NVE only and kept its definition for other ensembles.  The NVE simulation ran after this fix. I believe it shouldn't negatively affect the simulation results. 